### PR TITLE
Fix rpm_exclusion_filter runtime error

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -65,7 +65,7 @@
       state: present
       dest: "{{ build_dir }}/yum.conf"
       regexp: "^exclude=.*"
-      line: "exclude={{ rpm_exclusion_filter }}"
+      line: "exclude={{ config['rpm_exclusion_filter'] }}"
 
   - name: "Syncronize target repositories (this may take some time)"
     command: "reposync --gpgcheck -lm --repoid={{ item }} --download_path={{ content_dir }}/repos/ --arch=x86_64 -n -d -c {{ build_dir }}/yum.conf"


### PR DESCRIPTION
Run as is was generating following error:
```
TASK [Make sure downloader excludes packages that are not required] **************************************************************************************************************************************************************************
task path: /root/ocp-disconnected/build.yml:66
fatal: [localhost]: FAILED! => {
    "failed": true
}

MSG:

the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'rpm_exclusion_filter' is undefined

The error appears to have been in '/root/ocp-disconnected/build.yml': line 66, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


  - name: "Make sure downloader excludes packages that are not required"
    ^ here
```